### PR TITLE
Add support for custom s3 storage

### DIFF
--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -62,6 +62,7 @@ func encodeURL2Path(req *http.Request) (path string) {
 		path = "/" + strings.TrimSuffix(reqHost, customHostSuffix)
 		path += req.URL.Path
 		path = s3utils.EncodePath(path)
+		req.Header.Del(CustomStorageHost)
 		return
 	}
 	path = s3utils.EncodePath(req.URL.Path)

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -56,6 +56,14 @@ func encodeURL2Path(req *http.Request) (path string) {
 		path = s3utils.EncodePath(path)
 		return
 	}
+
+	customHostSuffix := "." + req.Header.Get(CustomStorageHost)
+	if customHostSuffix != "." && strings.Contains(reqHost, customHostSuffix){
+		path = "/" + strings.TrimSuffix(reqHost, customHostSuffix)
+		path += req.URL.Path
+		path = s3utils.EncodePath(path)
+		return
+	}
 	path = s3utils.EncodePath(req.URL.Path)
 	return
 }

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -58,7 +58,7 @@ func encodeURL2Path(req *http.Request) (path string) {
 	}
 
 	customHostSuffix := "." + req.Header.Get(CustomStorageHost)
-	if customHostSuffix != "." && strings.Contains(reqHost, customHostSuffix){
+	if customHostSuffix != "." && strings.HasSuffix(reqHost, customHostSuffix){
 		path = "/" + strings.TrimSuffix(reqHost, customHostSuffix)
 		path += req.URL.Path
 		path = s3utils.EncodePath(path)

--- a/pkg/s3signer/utils.go
+++ b/pkg/s3signer/utils.go
@@ -26,8 +26,12 @@ import (
 	"regexp"
 )
 
-// unsignedPayload - value to be set to X-Amz-Content-Sha256 header when
-const unsignedPayload = "UNSIGNED-PAYLOAD"
+const (
+	// CustomStorageHost is an internal HTTP Header that indicates a custom storage host usage
+	CustomStorageHost = "X-Custom-Storage-Host-3kl1Sc29"
+	// unsignedPayload - value to be set to X-Amz-Content-Sha256 header when
+	unsignedPayload = "UNSIGNED-PAYLOAD"
+)
 
 // sum256 calculate sha256 sum for an input byte array.
 func sum256(data []byte) []byte {


### PR DESCRIPTION
When verifying a V2 signature of a virtual-host style request, the `Error while verifying V2 signature for request` error is returned.
Using virtual-host style request, the bucket name (if present) from host [has to be rewritten](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationRequestCanonicalization) to the CanonicalizedResource, currently in only happend for Google's and Amazon's storage, there is no way to verify signatures when using a custom storage.