### PR TITLE
Read service value from request's header instead of hard coding

### DIFF
--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -59,7 +59,7 @@ func encodeURL2Path(req *http.Request) (path string) {
 
 	customHostSuffix := "." + req.Header.Get(CustomStorageHost)
 	if customHostSuffix != "." && strings.HasSuffix(reqHost, customHostSuffix){
-		path = "/" + strings.TrimSuffix(reqHost, customHostSuffix)
+		path = "/" + strings.TrimSuffix(reqHost, customHostSuffix[1:])
 		path += req.URL.Path
 		path = s3utils.EncodePath(path)
 		req.Header.Del(CustomStorageHost)


### PR DESCRIPTION
The code for calculating the V4 signature assumed that the `service` part of `stringToSign` is always `s3`, when in fact some clients use `execute-api` for example (`awscurl`) which caused the rejection of valid V4 signatures.