### PR TITLE
 Read service value from request's header instead of hard coding

### DIFF
--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -125,7 +125,7 @@ previousSignature, secretAccessKey string) string {
 // getSeedSignature - returns the seed signature for a given request.
 func (s *StreamingReader) setSeedSignature(req *http.Request) {
 	// Get canonical request
-	canonicalRequest := getCanonicalRequest(*req, ignoredStreamingHeaders)
+	canonicalRequest := getCanonicalRequest(req, ignoredStreamingHeaders)
 
 	// Get string to sign from canonical request.
 	stringToSign := getStringToSignV4(s.reqTime, s.region, s.service, canonicalRequest)
@@ -189,7 +189,7 @@ func (s *StreamingReader) setStreamingAuthHeader(req *http.Request) {
 	credential := GetCredential(s.accessKeyID, s.region, s.service, s.reqTime)
 	authParts := []string{
 		signV4Algorithm + " Credential=" + credential,
-		"SignedHeaders=" + getSignedHeaders(*req, ignoredStreamingHeaders),
+		"SignedHeaders=" + getSignedHeaders(req, ignoredStreamingHeaders),
 		"Signature=" + s.seedSignature,
 	}
 

--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -47,6 +47,7 @@ var ignoredStreamingHeaders = map[string]bool{
 	"Authorization": true,
 	"User-Agent":    true,
 	"Content-Type":  true,
+	"Content-Length":  true,
 }
 
 // getSignedChunkLength - calculates the length of chunk metadata

--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -44,10 +44,12 @@ const (
 // Request headers to be ignored while calculating seed signature for
 // a request.
 var ignoredStreamingHeaders = map[string]bool{
-	"Authorization": true,
-	"User-Agent":    true,
-	"Content-Type":  true,
+	"Authorization":   true,
+	"User-Agent":      true,
+	"Content-Type":    true,
 	"Content-Length":  true,
+	"Connection":      true,
+	"X-Forwarded-For": true,
 }
 
 // getSignedChunkLength - calculates the length of chunk metadata
@@ -145,7 +147,7 @@ type StreamingReader struct {
 	region          string
 	prevSignature   string
 	seedSignature   string
-	service 		string
+	service         string
 	contentLen      int64         // Content-Length from req header
 	baseReadCloser  io.ReadCloser // underlying io.Reader
 	bytesRead       int64         // bytes read from underlying io.Reader
@@ -216,7 +218,7 @@ region, service string, dataLen int64, reqTime time.Time) *http.Request {
 		secretAccessKey: secretAccessKey,
 		sessionToken:    sessionToken,
 		region:          region,
-		service: service,
+		service:         service,
 		reqTime:         reqTime,
 		chunkBuf:        make([]byte, payloadChunkSize),
 		contentLen:      dataLen,

--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -44,14 +44,13 @@ const (
 // Request headers to be ignored while calculating seed signature for
 // a request.
 var ignoredStreamingHeaders = map[string]bool{
-	"Authorization":  	true,
-	"Content-Type":   	true,
-	"Content-Length": 	true,
-	"User-Agent":     	true,
+	"Authorization": true,
+	"Content-Type":  true,
+	"User-Agent":    true,
 }
 
-// getSignedChunkLength - calculates the length of chunk metadata
-func getSignedChunkLength(chunkDataSize int64) int64 {
+// GetSignedChunkLength - calculates the length of chunk metadata
+func GetSignedChunkLength(chunkDataSize int64) int64 {
 	return int64(len(fmt.Sprintf("%x", chunkDataSize))) +
 		chunkSigConstLen +
 		signatureStrLen +
@@ -69,11 +68,11 @@ func getStreamLength(dataLen, chunkSize int64) int64 {
 	chunksCount := int64(dataLen / chunkSize)
 	remainingBytes := int64(dataLen % chunkSize)
 	streamLen := int64(0)
-	streamLen += chunksCount * getSignedChunkLength(chunkSize)
+	streamLen += chunksCount * GetSignedChunkLength(chunkSize)
 	if remainingBytes > 0 {
-		streamLen += getSignedChunkLength(remainingBytes)
+		streamLen += GetSignedChunkLength(remainingBytes)
 	}
-	streamLen += getSignedChunkLength(0)
+	streamLen += GetSignedChunkLength(0)
 	return streamLen
 }
 
@@ -115,7 +114,7 @@ func buildChunkHeader(chunkLen int64, signature string) []byte {
 
 // buildChunkSignature - returns chunk signature for a given chunk and previous signature.
 func buildChunkSignature(chunkData []byte, reqTime time.Time, region, service,
-previousSignature, secretAccessKey string) string {
+	previousSignature, secretAccessKey string) string {
 
 	chunkStringToSign := buildChunkStringToSign(reqTime, region, service, previousSignature, chunkData)
 	signingKey := getSigningKey(secretAccessKey, region, service, reqTime)
@@ -145,7 +144,7 @@ type StreamingReader struct {
 	region          string
 	prevSignature   string
 	seedSignature   string
-	service 		string
+	service         string
 	contentLen      int64         // Content-Length from req header
 	baseReadCloser  io.ReadCloser // underlying io.Reader
 	bytesRead       int64         // bytes read from underlying io.Reader
@@ -201,7 +200,7 @@ func (s *StreamingReader) setStreamingAuthHeader(req *http.Request, ignoredHeade
 // StreamingSignV4 - provides chunked upload signatureV4 support by
 // implementing io.Reader.
 func StreamingSignV4WithIgnoredHeaders(req *http.Request, accessKeyID, secretAccessKey, sessionToken,
-region, service string, dataLen int64, reqTime time.Time, ignoredHeaders map[string]bool) *http.Request {
+	region, service string, dataLen int64, reqTime time.Time, ignoredHeaders map[string]bool) *http.Request {
 
 	// Set headers needed for streaming signature.
 	prepareStreamingRequest(req, sessionToken, dataLen, reqTime)
@@ -216,7 +215,7 @@ region, service string, dataLen int64, reqTime time.Time, ignoredHeaders map[str
 		secretAccessKey: secretAccessKey,
 		sessionToken:    sessionToken,
 		region:          region,
-		service: service,
+		service:         service,
 		reqTime:         reqTime,
 		chunkBuf:        make([]byte, payloadChunkSize),
 		contentLen:      dataLen,
@@ -242,7 +241,7 @@ region, service string, dataLen int64, reqTime time.Time, ignoredHeaders map[str
 }
 
 func StreamingSignV4(req *http.Request, accessKeyID, secretAccessKey, sessionToken,
-region, service string, dataLen int64, reqTime time.Time) *http.Request {
+	region, service string, dataLen int64, reqTime time.Time) *http.Request {
 	return StreamingSignV4WithIgnoredHeaders(
 		req, accessKeyID, secretAccessKey, sessionToken,
 		region, service, dataLen, reqTime, ignoredStreamingHeaders)

--- a/pkg/s3signer/request-signature-streaming.go
+++ b/pkg/s3signer/request-signature-streaming.go
@@ -349,7 +349,7 @@ func (s *StreamingReader) Read(buf []byte) (int, error) {
 	return s.buf.Read(buf)
 }
 
-func extractNextChunkLength(buffer io.Reader) (uint16, int, error) {
+func extractNextChunkLength(buffer io.Reader) (int, int, error) {
 	currentCharacter := make([]byte, 1)
 	var chunkSizeInHex strings.Builder
 
@@ -369,7 +369,7 @@ func extractNextChunkLength(buffer io.Reader) (uint16, int, error) {
 
 	inHex := strings.TrimSpace(chunkSizeInHex.String())
 	size, _ := strconv.ParseUint(inHex, 16, 64)
-	return uint16(size), chunkSizeInHex.Len(), nil
+	return int(size), chunkSizeInHex.Len(), nil
 }
 
 // Close - this method makes underlying io.ReadCloser's Close method available.

--- a/pkg/s3signer/request-signature-streaming_test.go
+++ b/pkg/s3signer/request-signature-streaming_test.go
@@ -40,7 +40,7 @@ func TestGetSeedSignature(t *testing.T) {
 		t.Fatalf("Failed to parse time - %v", err)
 	}
 
-	req = StreamingSignV4(req, accessKeyID, secretAccessKeyID, "", "us-east-1", int64(dataLen), reqTime)
+	req = StreamingSignV4(req, accessKeyID, secretAccessKeyID, "", "us-east-1", "s3", int64(dataLen), reqTime)
 	actualSeedSignature := req.Body.(*StreamingReader).seedSignature
 
 	expectedSeedSignature := "38cab3af09aa15ddf29e26e36236f60fb6bfb6243a20797ae9a8183674526079"
@@ -54,9 +54,10 @@ func TestChunkSignature(t *testing.T) {
 	reqTime, _ := time.Parse(iso8601DateFormat, "20130524T000000Z")
 	previousSignature := "4f232c4386841ef735655705268965c44a0e4690baa4adea153f7db9fa80a0a9"
 	location := "us-east-1"
+	service := "s3"
 	secretAccessKeyID := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 	expectedSignature := "ad80c730a21e5b8d04586a2213dd63b9a0e99e0e2307b0ade35a65485a288648"
-	actualSignature := buildChunkSignature(chunkData, reqTime, location, previousSignature, secretAccessKeyID)
+	actualSignature := buildChunkSignature(chunkData, reqTime, location, service, previousSignature, secretAccessKeyID)
 	if actualSignature != expectedSignature {
 		t.Errorf("Expected %s but received %s", expectedSignature, actualSignature)
 	}
@@ -64,6 +65,7 @@ func TestChunkSignature(t *testing.T) {
 
 func TestSetStreamingAuthorization(t *testing.T) {
 	location := "us-east-1"
+	service := "s3"
 	secretAccessKeyID := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 	accessKeyID := "AKIAIOSFODNN7EXAMPLE"
 
@@ -74,7 +76,7 @@ func TestSetStreamingAuthorization(t *testing.T) {
 
 	dataLen := int64(65 * 1024)
 	reqTime, _ := time.Parse(iso8601DateFormat, "20130524T000000Z")
-	req = StreamingSignV4(req, accessKeyID, secretAccessKeyID, "", location, dataLen, reqTime)
+	req = StreamingSignV4(req, accessKeyID, secretAccessKeyID, "", location, service, dataLen, reqTime)
 
 	expectedAuthorization := "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length;x-amz-storage-class,Signature=38cab3af09aa15ddf29e26e36236f60fb6bfb6243a20797ae9a8183674526079"
 
@@ -87,6 +89,7 @@ func TestSetStreamingAuthorization(t *testing.T) {
 func TestStreamingReader(t *testing.T) {
 	reqTime, _ := time.Parse("20060102T150405Z", "20130524T000000Z")
 	location := "us-east-1"
+	service := "s3"
 	secretAccessKeyID := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 	accessKeyID := "AKIAIOSFODNN7EXAMPLE"
 	dataLen := int64(65 * 1024)
@@ -99,7 +102,7 @@ func TestStreamingReader(t *testing.T) {
 
 	baseReader := ioutil.NopCloser(bytes.NewReader(bytes.Repeat([]byte("a"), 65*1024)))
 	req.Body = baseReader
-	req = StreamingSignV4(req, accessKeyID, secretAccessKeyID, "", location, dataLen, reqTime)
+	req = StreamingSignV4(req, accessKeyID, secretAccessKeyID, "", location, service, dataLen, reqTime)
 
 	b, err := ioutil.ReadAll(req.Body)
 	if err != nil {

--- a/pkg/s3signer/request-signature-streaming_test.go
+++ b/pkg/s3signer/request-signature-streaming_test.go
@@ -19,7 +19,6 @@ package s3signer
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"testing"
 	"time"

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -59,7 +59,7 @@ func encodeURL2Path(req *http.Request) (path string) {
 
 	customHostSuffix := "." + req.Header.Get(CustomStorageHost)
 	if customHostSuffix != "." && strings.HasSuffix(reqHost, customHostSuffix){
-		path = "/" + strings.TrimSuffix(reqHost, customHostSuffix[1:])
+		path = "/" + strings.TrimSuffix(reqHost, customHostSuffix)
 		path += req.URL.Path
 		path = s3utils.EncodePath(path)
 		req.Header.Del(CustomStorageHost)

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -158,12 +158,9 @@ func SignV2(req http.Request, accessKeyID, secretAccessKey string, ignoredCanoni
 
 func calculateV2(req http.Request, access string, secret string, ignoredCanHeaders map[string]bool) string {
 	// Initial time.
-	d := time.Now().UTC()
 
 	// Add date if x-amz-date is not present.
-	if req.Header.Get("X-Amz-Date") == "" && req.Header.Get("Date") == "" {
-		req.Header.Set("Date", d.Format(http.TimeFormat))
-	}
+	req = addDateHeaderIfNeeded(req)
 
 	// Calculate HMAC for secretAccessKey.
 	stringToSign := stringToSignV2(req, ignoredCanHeaders)
@@ -176,6 +173,16 @@ func calculateV2(req http.Request, access string, secret string, ignoredCanHeade
 	encoder.Write(hm.Sum(nil))
 	encoder.Close()
 	return authHeader.String()
+}
+func addDateHeaderIfNeeded(req http.Request) http.Request {
+	return addDateHeaderWithTime(req, time.Now())
+}
+
+func addDateHeaderWithTime(req http.Request, time time.Time) http.Request {
+	if req.Header.Get("X-Amz-Date") == "" && req.Header.Get("Date") == "" {
+		req.Header.Set("Date", time.Format(http.TimeFormat))
+	}
+	return req
 }
 
 // From the Amazon docs:

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -59,7 +59,7 @@ func encodeURL2Path(req *http.Request) (path string) {
 
 	customHostSuffix := "." + req.Header.Get(CustomStorageHost)
 	if customHostSuffix != "." && strings.HasSuffix(reqHost, customHostSuffix){
-		path = "/" + strings.TrimSuffix(reqHost, customHostSuffix)
+		path = "/" + strings.TrimSuffix(reqHost, customHostSuffix[1:])
 		path += req.URL.Path
 		path = s3utils.EncodePath(path)
 		req.Header.Del(CustomStorageHost)

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -147,7 +147,7 @@ func SignV2(req *http.Request, accessKeyID, secretAccessKey string, ignoredCanon
 		return req
 	}
 
-	req = sanitizeDates(req)
+	req = sanitizeV2DateHeader(req, time.Now())
 	// Prepare auth header.
 	authHeader := calculateV2(req, accessKeyID, secretAccessKey, ignoredCanonicalizedHeaders)
 
@@ -170,14 +170,10 @@ func calculateV2(req *http.Request, access string, secret string, ignoredCanHead
 	encoder.Close()
 	return authHeader.String()
 }
-func sanitizeDates(req *http.Request) *http.Request {
-	return addAmazonDateHeader(req, time.Now())
 
-}
-
-func addAmazonDateHeader(req *http.Request, time time.Time) *http.Request {
-	req.Header.Set("Date", time.UTC().Format(http.TimeFormat))
-	req.Header.Set("x-amz-date", time.UTC().Format(iso8601DateFormat))
+func sanitizeV2DateHeader(req *http.Request, t time.Time) *http.Request {
+	req.Header.Set("Date", t.UTC().Format(http.TimeFormat))
+	req.Header.Del("x-amz-date")
 	return req
 }
 

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -175,12 +175,12 @@ func calculateV2(req *http.Request, access string, secret string, ignoredCanHead
 	return authHeader.String()
 }
 func sanitizeDates(req *http.Request) *http.Request {
-	req.Header.Del("Date")
 	return addAmazonDateHeader(req, time.Now())
 
 }
 
 func addAmazonDateHeader(req *http.Request, time time.Time) *http.Request {
+	req.Header.Del("Date")
 	req.Header.Set("x-amz-date", time.Format(iso8601DateFormat))
 	return req
 }

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -160,7 +160,7 @@ func calculateV2(req http.Request, access string, secret string, ignoredCanHeade
 	// Initial time.
 
 	// Add date if x-amz-date is not present.
-	req = addDateHeaderIfNeeded(req)
+	req = sanitizeDates(req)
 
 	// Calculate HMAC for secretAccessKey.
 	stringToSign := stringToSignV2(req, ignoredCanHeaders)
@@ -174,14 +174,14 @@ func calculateV2(req http.Request, access string, secret string, ignoredCanHeade
 	encoder.Close()
 	return authHeader.String()
 }
-func addDateHeaderIfNeeded(req http.Request) http.Request {
-	return addDateHeaderWithTime(req, time.Now())
+func sanitizeDates(req http.Request) http.Request {
+	req.Header.Del("Date")
+	return addAmazonDateHeader(req, time.Now())
+
 }
 
-func addDateHeaderWithTime(req http.Request, time time.Time) http.Request {
-	if req.Header.Get("X-Amz-Date") == "" && req.Header.Get("Date") == "" {
-		req.Header.Set("Date", time.Format(http.TimeFormat))
-	}
+func addAmazonDateHeader(req http.Request, time time.Time) http.Request {
+	req.Header.Set("x-amz-date", time.Format(iso8601DateFormat))
 	return req
 }
 

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -147,6 +147,7 @@ func SignV2(req *http.Request, accessKeyID, secretAccessKey string, ignoredCanon
 		return req
 	}
 
+	req = sanitizeDates(req)
 	// Prepare auth header.
 	authHeader := calculateV2(req, accessKeyID, secretAccessKey, ignoredCanonicalizedHeaders)
 
@@ -157,11 +158,6 @@ func SignV2(req *http.Request, accessKeyID, secretAccessKey string, ignoredCanon
 }
 
 func calculateV2(req *http.Request, access string, secret string, ignoredCanHeaders map[string]bool) string {
-	// Initial time.
-
-	// Add date if x-amz-date is not present.
-	req = sanitizeDates(req)
-
 	// Calculate HMAC for secretAccessKey.
 	stringToSign := stringToSignV2(req, ignoredCanHeaders)
 	hm := hmac.New(sha1.New, []byte(secret))

--- a/pkg/s3signer/request-signature-v2.go
+++ b/pkg/s3signer/request-signature-v2.go
@@ -176,8 +176,8 @@ func sanitizeDates(req *http.Request) *http.Request {
 }
 
 func addAmazonDateHeader(req *http.Request, time time.Time) *http.Request {
-	req.Header.Del("Date")
-	req.Header.Set("x-amz-date", time.Format(iso8601DateFormat))
+	req.Header.Set("Date", time.UTC().Format(http.TimeFormat))
+	req.Header.Set("x-amz-date", time.UTC().Format(iso8601DateFormat))
 	return req
 }
 

--- a/pkg/s3signer/request-signature-v2_test.go
+++ b/pkg/s3signer/request-signature-v2_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"net/url"
 	"net/http"
+	"bytes"
+	"github.com/stretchr/testify/assert"
 )
 
 // Tests for 'func TestResourceListSorting(t *testing.T)'.
@@ -67,4 +69,14 @@ func TestEncodeURL2PathWithVirtualHost(t *testing.T) {
 			t.Fatalf("Failed to translate - %s", testCases[index])
 		}
 	}
+}
+
+func TestShouldIngnoreTheSpecifiedHeadersDuringV2Signing(t *testing.T) {
+	buf := new(bytes.Buffer)
+	req := http.Request{}
+	req.Header = http.Header{}
+	req.Header.Add("x-amz-meta-test-header", "test-value")
+	req.Header.Add("x-amz-meta-date", "123")
+	writeCanonicalizedHeaders(buf, req, map[string]bool {"x-amz-meta-test-header": true})
+	assert.Equal(t, buf.String(), "x-amz-meta-date:123\n")
 }

--- a/pkg/s3signer/request-signature-v2_test.go
+++ b/pkg/s3signer/request-signature-v2_test.go
@@ -64,7 +64,7 @@ func TestEncodeURL2PathWithVirtualHost(t *testing.T) {
 
 	for index, testResult := range testResults {
 		if !testResult {
-			t.Fatalf("Failed to encode - %s", testCases[index])
+			t.Fatalf("Failed to translate - %s", testCases[index])
 		}
 	}
 }

--- a/pkg/s3signer/request-signature-v2_test.go
+++ b/pkg/s3signer/request-signature-v2_test.go
@@ -77,6 +77,6 @@ func TestShouldIngnoreTheSpecifiedHeadersDuringV2Signing(t *testing.T) {
 	req.Header = http.Header{}
 	req.Header.Add("x-amz-meta-test-header", "test-value")
 	req.Header.Add("x-amz-meta-date", "123")
-	writeCanonicalizedHeaders(buf, req, map[string]bool {"x-amz-meta-test-header": true})
+	writeCanonicalizedHeaders(buf, &req, map[string]bool {"x-amz-meta-test-header": true})
 	assert.Equal(t, buf.String(), "x-amz-meta-date:123\n")
 }

--- a/pkg/s3signer/request-signature-v4.go
+++ b/pkg/s3signer/request-signature-v4.go
@@ -73,7 +73,7 @@ const (
 ///
 ///      Is skipped for obvious reasons
 ///
-var v4IgnoredHeaders = map[string]bool{
+var defaultV4IgnoredHeaders = map[string]bool{
 	"Authorization":  	true,
 	"Content-Type":   	true,
 	"Content-Length": 	true,
@@ -224,7 +224,7 @@ func PreSignV4(req *http.Request, accessKeyID, secretAccessKey, sessionToken, lo
 	credential := GetCredential(accessKeyID, location, service, t)
 
 	// Get all signed headers.
-	signedHeaders := getSignedHeaders(req, v4IgnoredHeaders)
+	signedHeaders := getSignedHeaders(req, defaultV4IgnoredHeaders)
 
 	// Set URL query.
 	query := req.URL.Query()
@@ -240,7 +240,7 @@ func PreSignV4(req *http.Request, accessKeyID, secretAccessKey, sessionToken, lo
 	req.URL.RawQuery = query.Encode()
 
 	// Get canonical request.
-	canonicalRequest := getCanonicalRequest(req, v4IgnoredHeaders)
+	canonicalRequest := getCanonicalRequest(req, defaultV4IgnoredHeaders)
 
 	// Get string to sign from canonical request.
 	stringToSign := getStringToSignV4(t, location, service, canonicalRequest)
@@ -270,6 +270,12 @@ func PostPresignSignatureV4(policyBase64 string, t time.Time, secretAccessKey, l
 // SignV4 sign the request before Do(), in accordance with
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html.
 func SignV4(req *http.Request, accessKeyID, secretAccessKey, sessionToken, location, service string) *http.Request {
+	return SignV4WithIgnoredHeaders(req, accessKeyID, secretAccessKey, sessionToken, location, service, defaultV4IgnoredHeaders)
+}
+
+// SignV4WithIgnoredHeaders sign the request before Do(), in accordance with
+// http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html.
+func SignV4WithIgnoredHeaders(req *http.Request, accessKeyID, secretAccessKey, sessionToken, location, service string, ignoredHeaders map[string]bool) *http.Request {
 	// Signature calculation is not needed for anonymous credentials.
 	if accessKeyID == "" || secretAccessKey == "" {
 		return req
@@ -287,7 +293,7 @@ func SignV4(req *http.Request, accessKeyID, secretAccessKey, sessionToken, locat
 	}
 
 	// Get canonical request.
-	canonicalRequest := getCanonicalRequest(req, v4IgnoredHeaders)
+	canonicalRequest := getCanonicalRequest(req, ignoredHeaders)
 
 	// Get string to sign from canonical request.
 	stringToSign := getStringToSignV4(t, location, service, canonicalRequest)
@@ -299,7 +305,7 @@ func SignV4(req *http.Request, accessKeyID, secretAccessKey, sessionToken, locat
 	credential := GetCredential(accessKeyID, location, service, t)
 
 	// Get all signed headers.
-	signedHeaders := getSignedHeaders(req, v4IgnoredHeaders)
+	signedHeaders := getSignedHeaders(req, ignoredHeaders)
 
 	// Calculate signature.
 	signature := getSignature(signingKey, stringToSign)

--- a/pkg/s3signer/request-signature-v4.go
+++ b/pkg/s3signer/request-signature-v4.go
@@ -279,7 +279,7 @@ func SignV4(req http.Request, accessKeyID, secretAccessKey, sessionToken, locati
 	t := time.Now().UTC()
 
 	// Set x-amz-date.
-	req = addDateHeaderWithTime(req, t)
+	req = addAmazonDateHeader(req, t)
 
 	// Set session token if available.
 	if sessionToken != "" {

--- a/pkg/s3signer/request-signature-v4.go
+++ b/pkg/s3signer/request-signature-v4.go
@@ -279,7 +279,7 @@ func SignV4(req http.Request, accessKeyID, secretAccessKey, sessionToken, locati
 	t := time.Now().UTC()
 
 	// Set x-amz-date.
-	req.Header.Set("X-Amz-Date", t.Format(iso8601DateFormat))
+	req = addDateHeaderWithTime(req, t)
 
 	// Set session token if available.
 	if sessionToken != "" {

--- a/pkg/s3signer/request-signature-v4.go
+++ b/pkg/s3signer/request-signature-v4.go
@@ -74,10 +74,12 @@ const (
 ///      Is skipped for obvious reasons
 ///
 var v4IgnoredHeaders = map[string]bool{
-	"Authorization":  true,
-	"Content-Type":   true,
-	"Content-Length": true,
-	"User-Agent":     true,
+	"Authorization":  	true,
+	"Content-Type":   	true,
+	"Content-Length": 	true,
+	"User-Agent":     	true,
+	"Connection": 		true,
+
 }
 
 // getSigningKey hmac seed to calculate final signature.

--- a/pkg/s3signer/request-signature-v4_test.go
+++ b/pkg/s3signer/request-signature-v4_test.go
@@ -28,7 +28,7 @@ func TestRequestHost(t *testing.T) {
 	req, _ := buildRequest("dynamodb", "us-east-1", "{}")
 	req.URL.RawQuery = "Foo=z&Foo=o&Foo=m&Foo=a"
 	req.Host = "myhost"
-	canonicalHeaders := getCanonicalHeaders(req, v4IgnoredHeaders)
+	canonicalHeaders := getCanonicalHeaders(req, defaultV4IgnoredHeaders)
 
 	if !strings.Contains(canonicalHeaders, "host:"+req.Host) {
 		t.Errorf("canonical host header invalid")

--- a/pkg/s3signer/request-signature-v4_test.go
+++ b/pkg/s3signer/request-signature-v4_test.go
@@ -28,7 +28,7 @@ func TestRequestHost(t *testing.T) {
 	req, _ := buildRequest("dynamodb", "us-east-1", "{}")
 	req.URL.RawQuery = "Foo=z&Foo=o&Foo=m&Foo=a"
 	req.Host = "myhost"
-	canonicalHeaders := getCanonicalHeaders(*req, v4IgnoredHeaders)
+	canonicalHeaders := getCanonicalHeaders(req, v4IgnoredHeaders)
 
 	if !strings.Contains(canonicalHeaders, "host:"+req.Host) {
 		t.Errorf("canonical host header invalid")

--- a/pkg/s3signer/request-signature-v4_test.go
+++ b/pkg/s3signer/request-signature-v4_test.go
@@ -28,7 +28,7 @@ func TestRequestHost(t *testing.T) {
 	req, _ := buildRequest("dynamodb", "us-east-1", "{}")
 	req.URL.RawQuery = "Foo=z&Foo=o&Foo=m&Foo=a"
 	req.Host = "myhost"
-	canonicalHeaders := getCanonicalHeaders(req, defaultV4IgnoredHeaders)
+	canonicalHeaders := getCanonicalHeaders(req, v4IgnoredHeaders)
 
 	if !strings.Contains(canonicalHeaders, "host:"+req.Host) {
 		t.Errorf("canonical host header invalid")

--- a/pkg/s3signer/request-signature_test.go
+++ b/pkg/s3signer/request-signature_test.go
@@ -39,12 +39,12 @@ func TestSignatureCalculation(t *testing.T) {
 		t.Fatal("Error: anonymous credentials should not have Signature query resource.")
 	}
 
-	req = SignV2(*req, "", "")
+	req = SignV2(*req, "", "", make(map[string]bool))
 	if req.Header.Get("Authorization") != "" {
 		t.Fatal("Error: anonymous credentials should not have Authorization header.")
 	}
 
-	req = PreSignV2(*req, "", "", 0)
+	req = PreSignV2(*req, "", "", 0, make(map[string]bool))
 	if strings.Contains(req.URL.RawQuery, "Signature") {
 		t.Fatal("Error: anonymous credentials should not have Signature query resource.")
 	}
@@ -59,12 +59,12 @@ func TestSignatureCalculation(t *testing.T) {
 		t.Fatal("Error: normal credentials should have Signature query resource.")
 	}
 
-	req = SignV2(*req, "ACCESS-KEY", "SECRET-KEY")
+	req = SignV2(*req, "ACCESS-KEY", "SECRET-KEY", make(map[string]bool))
 	if req.Header.Get("Authorization") == "" {
 		t.Fatal("Error: normal credentials should have Authorization header.")
 	}
 
-	req = PreSignV2(*req, "ACCESS-KEY", "SECRET-KEY", 0)
+	req = PreSignV2(*req, "ACCESS-KEY", "SECRET-KEY", 0, make(map[string]bool))
 	if !strings.Contains(req.URL.RawQuery, "Signature") {
 		t.Fatal("Error: normal credentials should not have Signature query resource.")
 	}

--- a/pkg/s3signer/request-signature_test.go
+++ b/pkg/s3signer/request-signature_test.go
@@ -29,42 +29,42 @@ func TestSignatureCalculation(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
-	req = SignV4(*req, "", "", "", "us-east-1", "s3")
+	req = SignV4(req, "", "", "", "us-east-1", "s3")
 	if req.Header.Get("Authorization") != "" {
 		t.Fatal("Error: anonymous credentials should not have Authorization header.")
 	}
 
-	req = PreSignV4(*req, "", "", "", "us-east-1", "s3", 0)
+	req = PreSignV4(req, "", "", "", "us-east-1", "s3", 0)
 	if strings.Contains(req.URL.RawQuery, "X-Amz-Signature") {
 		t.Fatal("Error: anonymous credentials should not have Signature query resource.")
 	}
 
-	req = SignV2(*req, "", "", make(map[string]bool))
+	req = SignV2(req, "", "", make(map[string]bool))
 	if req.Header.Get("Authorization") != "" {
 		t.Fatal("Error: anonymous credentials should not have Authorization header.")
 	}
 
-	req = PreSignV2(*req, "", "", 0, make(map[string]bool))
+	req = PreSignV2(req, "", "", 0, make(map[string]bool))
 	if strings.Contains(req.URL.RawQuery, "Signature") {
 		t.Fatal("Error: anonymous credentials should not have Signature query resource.")
 	}
 
-	req = SignV4(*req, "ACCESS-KEY", "SECRET-KEY", "", "us-east-1", "s3")
+	req = SignV4(req, "ACCESS-KEY", "SECRET-KEY", "", "us-east-1", "s3")
 	if req.Header.Get("Authorization") == "" {
 		t.Fatal("Error: normal credentials should have Authorization header.")
 	}
 
-	req = PreSignV4(*req, "ACCESS-KEY", "SECRET-KEY", "", "us-east-1", "s3", 0)
+	req = PreSignV4(req, "ACCESS-KEY", "SECRET-KEY", "", "us-east-1", "s3", 0)
 	if !strings.Contains(req.URL.RawQuery, "X-Amz-Signature") {
 		t.Fatal("Error: normal credentials should have Signature query resource.")
 	}
 
-	req = SignV2(*req, "ACCESS-KEY", "SECRET-KEY", make(map[string]bool))
+	req = SignV2(req, "ACCESS-KEY", "SECRET-KEY", make(map[string]bool))
 	if req.Header.Get("Authorization") == "" {
 		t.Fatal("Error: normal credentials should have Authorization header.")
 	}
 
-	req = PreSignV2(*req, "ACCESS-KEY", "SECRET-KEY", 0, make(map[string]bool))
+	req = PreSignV2(req, "ACCESS-KEY", "SECRET-KEY", 0, make(map[string]bool))
 	if !strings.Contains(req.URL.RawQuery, "Signature") {
 		t.Fatal("Error: normal credentials should not have Signature query resource.")
 	}

--- a/pkg/s3signer/request-signature_test.go
+++ b/pkg/s3signer/request-signature_test.go
@@ -29,12 +29,12 @@ func TestSignatureCalculation(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
-	req = SignV4(*req, "", "", "", "us-east-1")
+	req = SignV4(*req, "", "", "", "us-east-1", "s3")
 	if req.Header.Get("Authorization") != "" {
 		t.Fatal("Error: anonymous credentials should not have Authorization header.")
 	}
 
-	req = PreSignV4(*req, "", "", "", "us-east-1", 0)
+	req = PreSignV4(*req, "", "", "", "us-east-1", "s3", 0)
 	if strings.Contains(req.URL.RawQuery, "X-Amz-Signature") {
 		t.Fatal("Error: anonymous credentials should not have Signature query resource.")
 	}
@@ -49,12 +49,12 @@ func TestSignatureCalculation(t *testing.T) {
 		t.Fatal("Error: anonymous credentials should not have Signature query resource.")
 	}
 
-	req = SignV4(*req, "ACCESS-KEY", "SECRET-KEY", "", "us-east-1")
+	req = SignV4(*req, "ACCESS-KEY", "SECRET-KEY", "", "us-east-1", "s3")
 	if req.Header.Get("Authorization") == "" {
 		t.Fatal("Error: normal credentials should have Authorization header.")
 	}
 
-	req = PreSignV4(*req, "ACCESS-KEY", "SECRET-KEY", "", "us-east-1", 0)
+	req = PreSignV4(*req, "ACCESS-KEY", "SECRET-KEY", "", "us-east-1", "s3", 0)
 	if !strings.Contains(req.URL.RawQuery, "X-Amz-Signature") {
 		t.Fatal("Error: normal credentials should have Signature query resource.")
 	}

--- a/pkg/s3signer/utils.go
+++ b/pkg/s3signer/utils.go
@@ -57,7 +57,7 @@ func getHostAddr(req *http.Request) string {
 
 const (
 	regexV2Algorithm = "AWS +(?P<access_key>[a-zA-Z0-9_-]+):(?P<signature>(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)"
-	regexV4Algorithm = "AWS4-HMAC-SHA256 +Credential=(?P<access_key>[a-zA-Z0-9_-]+)/[0-9]+/(?P<region>[a-zA-Z0-9-]*)/[a-zA-Z0-9-]+/aws4_request, +SignedHeaders=(?P<signed_headers>[a-z0-9-;]+), +Signature=(?P<signature>[a-z0-9]+)"
+	regexV4Algorithm = "AWS4-HMAC-SHA256 +Credential=(?P<access_key>[a-zA-Z0-9_-]+)/[0-9]+/(?P<region>[a-zA-Z0-9-]*)/(?P<service>[a-zA-Z0-9]+)/aws4_request, +SignedHeaders=(?P<signed_headers>[a-z0-9-;]+), +Signature=(?P<signature>[a-z0-9]+)"
 )
 
 var reV2 = regexp.MustCompile(regexV2Algorithm)
@@ -69,6 +69,7 @@ type parsedAuthorizationHeader struct {
 	signature     string
 	signedHeaders string
 	region        string
+	service		  string
 }
 
 // extractAuthorizationHeader - extract S3 authorization header details
@@ -80,7 +81,8 @@ func extractAuthorizationHeader(authorizationHeader string) (authHeader parsedAu
 
 	if reV4.MatchString(authorizationHeader) {
 		match := reV4.FindStringSubmatch(authorizationHeader)
-		return parsedAuthorizationHeader{accessKey: match[1], signature: match[4], region: match[2], signedHeaders: match[3], version: signV4Algorithm}, nil
+		return parsedAuthorizationHeader{accessKey: match[1], signature: match[5], region: match[2], signedHeaders: match[4],
+			version: signV4Algorithm, service: match[3]}, nil
 	}
 
 	return parsedAuthorizationHeader{}, fmt.Errorf("cannot find correct authorization header")

--- a/pkg/s3signer/utils.go
+++ b/pkg/s3signer/utils.go
@@ -57,7 +57,7 @@ func getHostAddr(req *http.Request) string {
 
 const (
 	regexV2Algorithm = "AWS +(?P<access_key>[a-zA-Z0-9_-]+):(?P<signature>(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)"
-	regexV4Algorithm = "AWS4-HMAC-SHA256 +Credential=(?P<access_key>[a-zA-Z0-9_-]+)/[0-9]+/(?P<region>[a-zA-Z0-9-]*)/(?P<service>[a-zA-Z0-9_-]+)/aws4_request,( +)?SignedHeaders=(?P<signed_headers>[a-z0-9-;.]+),( +)?Signature=(?P<signature>[a-z0-9]+)"
+	regexV4Algorithm = "AWS4-HMAC-SHA256 +Credential=(?P<access_key>.+)/[0-9]+/(?P<region>[a-zA-Z0-9-]*)/(?P<service>[a-zA-Z0-9_-]+)/aws4_request,( +)?SignedHeaders=(?P<signed_headers>[a-z0-9-;.]+),( +)?Signature=(?P<signature>[a-z0-9]+)"
 )
 
 var reV2 = regexp.MustCompile(regexV2Algorithm)
@@ -69,7 +69,7 @@ type parsedAuthorizationHeader struct {
 	signature     string
 	signedHeaders string
 	region        string
-	service		  string
+	service       string
 }
 
 // extractAuthorizationHeader - extract S3 authorization header details

--- a/pkg/s3signer/utils.go
+++ b/pkg/s3signer/utils.go
@@ -57,7 +57,7 @@ func getHostAddr(req *http.Request) string {
 
 const (
 	regexV2Algorithm = "AWS +(?P<access_key>[a-zA-Z0-9_-]+):(?P<signature>(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)"
-	regexV4Algorithm = "AWS4-HMAC-SHA256 +Credential=(?P<access_key>[a-zA-Z0-9_-]+)/[0-9]+/(?P<region>[a-zA-Z0-9-]*)/(?P<service>[a-zA-Z0-9_-]+)/aws4_request,( +)?SignedHeaders=(?P<signed_headers>[a-z0-9-;]+),( +)?Signature=(?P<signature>[a-z0-9]+)"
+	regexV4Algorithm = "AWS4-HMAC-SHA256 +Credential=(?P<access_key>[a-zA-Z0-9_-]+)/[0-9]+/(?P<region>[a-zA-Z0-9-]*)/(?P<service>[a-zA-Z0-9_-]+)/aws4_request,( +)?SignedHeaders=(?P<signed_headers>[a-z0-9-;.]+),( +)?Signature=(?P<signature>[a-z0-9]+)"
 )
 
 var reV2 = regexp.MustCompile(regexV2Algorithm)

--- a/pkg/s3signer/utils.go
+++ b/pkg/s3signer/utils.go
@@ -57,7 +57,7 @@ func getHostAddr(req *http.Request) string {
 
 const (
 	regexV2Algorithm = "AWS +(?P<access_key>[a-zA-Z0-9_-]+):(?P<signature>(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)"
-	regexV4Algorithm = "AWS4-HMAC-SHA256 +Credential=(?P<access_key>[a-zA-Z0-9_-]+)/[0-9]+/(?P<region>[a-zA-Z0-9-]*)/(?P<service>[a-zA-Z0-9]+)/aws4_request, +SignedHeaders=(?P<signed_headers>[a-z0-9-;]+), +Signature=(?P<signature>[a-z0-9]+)"
+	regexV4Algorithm = "AWS4-HMAC-SHA256 +Credential=(?P<access_key>[a-zA-Z0-9_-]+)/[0-9]+/(?P<region>[a-zA-Z0-9-]*)/(?P<service>[a-zA-Z0-9_-]+)/aws4_request,( +)?SignedHeaders=(?P<signed_headers>[a-z0-9-;]+),( +)?Signature=(?P<signature>[a-z0-9]+)"
 )
 
 var reV2 = regexp.MustCompile(regexV2Algorithm)
@@ -81,7 +81,7 @@ func extractAuthorizationHeader(authorizationHeader string) (authHeader parsedAu
 
 	if reV4.MatchString(authorizationHeader) {
 		match := reV4.FindStringSubmatch(authorizationHeader)
-		return parsedAuthorizationHeader{accessKey: match[1], signature: match[5], region: match[2], signedHeaders: match[4],
+		return parsedAuthorizationHeader{accessKey: match[1], signature: match[7], region: match[2], signedHeaders: match[5],
 			version: signV4Algorithm, service: match[3]}, nil
 	}
 


### PR DESCRIPTION
The code for calculating the V4 signature assumed that the `service` part of `stringToSign` is always `s3`, when in fact some clients use `execute-api` for example (`awscurl`) which caused the rejection of valid V4 signatures.